### PR TITLE
Style enhancements, solving problems mentioned in issue #32

### DIFF
--- a/src/components/ParticipantImages.js
+++ b/src/components/ParticipantImages.js
@@ -23,7 +23,7 @@ export default function ParticipantImages() {
   return (
     <section className={styles.imageCarousel}>
       <div>
-        <p className='hero__subtitle'>
+        <p className={`hero__subtitle ${styles.subTitle}`}>
           Meet our participants (more photos to come soon)
         </p>
       </div>

--- a/src/components/ParticipantImages.js
+++ b/src/components/ParticipantImages.js
@@ -33,7 +33,7 @@ export default function ParticipantImages() {
           {ImageList.map((props, idx) => (
             <div key={idx}>
               <img src={useBaseUrl(props.img)} />
-              <p className="legend">{props.title}</p>
+              <p className={styles.imageCarouselCaption}>{props.title}</p>
             </div>
           ))}
         </Carousel>

--- a/src/components/ParticipantImages.module.css
+++ b/src/components/ParticipantImages.module.css
@@ -8,7 +8,7 @@
 .imageCarousel {
   display: flex;
   align-items: center;
-  padding: 2rem 0;
+  padding: 2rem 1rem;
   width: 100%;
   -webkit-box-orient: vertical !important;
   -webkit-box-direction: normal !important;
@@ -18,4 +18,24 @@
 
 .subTitle {
   padding: 0 1rem;
+}
+
+.imageCarouselCaption {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.9) !important;
+  color: #fff;
+  padding: 10px;
+  font-size: 20px;
+  text-align: center;
+  border-radius: 2rem;
+}
+
+@media screen and (max-width: 700px) {
+  .imageCarouselCaption {
+    font-size: 10px;
+  }
 }

--- a/src/components/ParticipantImages.module.css
+++ b/src/components/ParticipantImages.module.css
@@ -15,3 +15,7 @@
   -ms-flex-direction: column !important;
   flex-direction: column !important;
 }
+
+.subTitle {
+  padding: 0 1rem;
+}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -20,11 +20,6 @@
     flex-direction: column;
   }
 }
-@media screen and (max-width: 627px) {
-  .buttons {
-    row-gap: 10px;
-  }
-}
 
 .buttons {
   display: flex;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -16,6 +16,14 @@
   .heroBanner {
     padding: 2rem;
   }
+  .buttons {
+    flex-direction: column;
+  }
+}
+@media screen and (max-width: 627px) {
+  .buttons {
+    row-gap: 10px;
+  }
 }
 
 .buttons {


### PR DESCRIPTION
## Project

Style enhancement as mentioned in #32 

### Changes

- Fix button oveflow in homescreen
  - In the current home screen, the about buttons of 2020 and 2021 projects overflow the screen in small devices
  - Added flex direction for small screen to solve this issue
- Changed style for Crousel image caption
- Added padding in Image crousel title

### Notes
- Footer links is not centred in this PR

Closes #32