### PR TITLE
chore(docs): add week 3 report for Debian packaging project

### DIFF
--- a/docs/2025/debian-packaging/updates/2025-08-02.md
+++ b/docs/2025/debian-packaging/updates/2025-08-02.md
@@ -1,0 +1,79 @@
+---
+title: Week 3
+author: Ahmed Gamal
+author_url: https://github.com/Ahmed-Gamal24
+tags: [gsoc25, debian-packaging, fossology]
+---
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2025 Ahmed Gamal <ahmed.gamal9541@gmail.com>
+-->
+
+# Week 3
+
+## Debian Packaging Progress
+
+This week focused on scaling up the packaging effort and modernizing the FOSSology build system:
+
+- **Packaged 20+ PHP libraries** for Debian, ensuring clean builds and installs, and filed ITPs for each package.
+- **Modernized FOSSology packaging** by migrating to CMake, cleaning up dependencies, removing vendored libraries, and fixing build errors.
+- **Ensured all FOSSology dependencies** are provided as system packages, not bundled, improving maintainability and security.
+- **Built and tested FOSSology** and all PHP packages in a clean Docker environment to ensure reproducibility.
+- **Solved version pinning issues** by using `apt-mark hold` to prevent unwanted upgrades, and switched to `composer.phar` to avoid Composer pulling newer, incompatible package versions.
+
+## New PHP Packages Created
+
+This week, I created and filed ITPs for the following 19 additional PHP packages:
+
+- `php-nikic-php-parser` ([ITP #1109613](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109613))
+- `php-fig-http-message-util` ([ITP #1109614](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109614))
+- `php-ralouphie-getallheaders` ([ITP #1109615](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109615))
+- `php-adriansuter-php-autoload-override` ([ITP #1109618](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109618))
+- `php-http-interop-http-factory-tests` ([ITP #1109619](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109619))
+- `php-phpstan` ([ITP #1109620](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109620))
+- `php-squizlabs-php-codesniffer` ([ITP #1109621](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109621))
+- `php-weirdan-prophecy-shim` ([ITP #1109622](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109622))
+- `php-psr-http-factory` ([ITP #1109624](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109624))
+- `php-psr-http-message` ([ITP #1109625](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109625))
+- `php-php-http-psr7-integration-tests` ([ITP #1109630](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109630))
+- `php-symfony-dependency-injection` ([ITP #1109631](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109631))
+- `php-slim` ([ITP #1109632](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109632))
+- `php-psr-container` ([ITP #1109633](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109633))
+- `php-symfony-console` ([ITP #1109634](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109634))
+- `php-symfony-debug` ([ITP #1109638](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109638))
+- `php-psr-log` ([ITP #1109640](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109640))
+- `php-laminas-escaper` ([ITP #1109795](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109795))
+- `php-twig-extensions` ([ITP #1109798](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109798))
+
+---
+
+## Meeting 1
+
+**Date:** Jul 22, 2025
+
+Discussed the progress on packaging additional PHP dependencies and the modernization of the FOSSology build system. The mentor provided feedback on the CMake migration and emphasized the importance of ensuring all packages build cleanly in a controlled environment.
+
+---
+
+## Meeting 2
+
+**Date:** Jul 23, 2025
+
+A technical review meeting focused on the Docker build environment setup and version pinning strategies. We discussed the challenges of managing Composer dependencies and the mentor suggested best practices for handling version conflicts and ensuring reproducible builds.
+
+---
+
+## Next Steps
+
+- **Install the built FOSSology components** and resolve any installation errors.
+- **Aim to have all FOSSology components and required packages** built and installed successfully.
+- Continue monitoring the ITP processes and respond to any feedback from the Debian community.
+
+---
+
+## Planning for Week 4
+
+- Complete the installation and testing of all FOSSology components.
+- Address any remaining build or installation issues.
+- Begin documentation of the complete packaging workflow for future maintainers.


### PR DESCRIPTION
## Project

Debian packaging for Fossology

### Changes

Added Week 3 report for the Debian packaging project
Documented packaging of 20+ additional PHP libraries with ITP filings
Updated progress on FOSSology build system modernization (CMake migration, dependency cleanup)
Added details on Docker environment testing and version pinning solutions
Included comprehensive list of 19 new PHP packages created this week with their corresponding ITP links
