### PR TITLE
docs(2026/enhancing-atarashi): add intro and community bonding update

### DIFF
--- a/docs/2026/enhancing-atarashi/index.md
+++ b/docs/2026/enhancing-atarashi/index.md
@@ -3,3 +3,79 @@ sidebar_position: 5
 title: Introduction
 slug: /2026/enhancing-atarashi/
 ---
+
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2026 Swapnil Dutta <swapnil@rycerz.es>
+-->
+
+## Author
+
+[Swapnil Dutta](https://github.com/rycerzes)
+
+## Contact info
+
+- [Email](mailto:swapnil@rycerz.es)
+- [LinkedIn](https://www.linkedin.com/in/swapnildutta1)
+
+## Project title
+
+Enhancing Nirjas & Atarashi for Accurate, Scalable License Intelligence
+
+## What's the project about?
+
+This project improves FOSSology's license intelligence pipeline in two connected parts:
+
+1. **Nirjas revamp**
+   - Move from regex-heavy extraction to **Tree-sitter based parsing** for robust, language-aware comment extraction.
+   - Build a scalable multi-language extraction flow using language packs and compatibility checks.
+
+2. **Atarashi upgrade**
+   - Move from broad full-file matching to a **signal-driven retrieval + classification approach**.
+   - Support confidence-aware predictions and a safer **`UNKNOWN` / abstain** behavior for weak evidence.
+
+The data and model work is backed by an upgraded Minerva-style dataset pipeline, with balanced task-specific datasets for both Nirjas and Atarashi.
+
+## What should be done?
+
+### 1) Tree-sitter based Nirjas extraction pipeline
+
+- Generalize the existing Tree-sitter proof-of-concept into a reusable extraction architecture.
+- Build language-pack management and parser compatibility validation.
+- Maintain a normalized extraction contract for downstream consumers.
+- Add fallback behavior for unsupported/incompatible parsers.
+
+### 2) Dataset generation for Nirjas and Atarashi
+
+- Use a unified data pipeline over multiple sources (e.g. license corpora + non-license comments).
+- Build train/validation/test splits for:
+  - **Nirjas** (`license_comment` vs `non_license_comment`)
+  - **Atarashi** (`license_id` multiclass)
+- Include hard negatives, augmentation, and near-dedup for better generalization.
+
+### 3) Nirjas classifier
+
+- Select strong teacher embeddings using benchmark context + task evaluations.
+- Distill to lightweight `model2vec` representations.
+- Train a binary classifier optimized for high-throughput CPU inference.
+
+### 4) Atarashi model path selection
+
+- Implement and compare two tracks:
+  - Distilled `model2vec` retrieval/classification path.
+  - Fine-tuned + quantized embedding baseline for CPU-first deployment.
+- Select production path using quality/latency trade-offs on held-out data.
+
+### 5) Confidence-aware output and integration
+
+- Add confidence scoring and `UNKNOWN` behavior in low-evidence cases.
+- Integrate Nirjas → Atarashi flow end-to-end.
+- Add tests, documentation, and reproducible evaluation steps.
+
+## Expected outcomes
+
+- More accurate and robust extraction of license-relevant comments from real-world source files.
+- Faster and more reliable license prediction on high-signal fragments.
+- Better scalability and maintainability for FOSSology's license detection workflows.
+- Clearer model outputs for compliance workflows with confidence and abstention support.

--- a/docs/2026/enhancing-atarashi/updates/2026-05-24.md
+++ b/docs/2026/enhancing-atarashi/updates/2026-05-24.md
@@ -1,0 +1,79 @@
+---
+title: Community Bonding
+author: Swapnil Dutta
+tags: [gsoc26, nirjas, atarashi]
+---
+
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2026 Swapnil Dutta <swapnil@rycerz.es>
+-->
+
+# Community Bonding (Initial Weeks)
+
+*(May 8, 2026 - May 24, 2026)*
+
+## Meeting 1 (Introductory Community Session)
+
+*(May 8, 2026)*
+
+### Attendees
+
+- Full FOSSology GSoC 2026 community:
+  - Org admins
+  - Mentors
+  - Contributors
+
+### Discussion
+
+- Introduction session with mentors and contributors across all GSoC 2026 projects.
+- Shared community expectations around communication, weekly updates, and collaboration.
+- Discussed development workflows and contribution etiquette in FOSSology.
+- Aligned on using regular mentor syncs and progress reporting as part of project execution.
+
+## Meeting 2 (Project-Specific Initial Discussion)
+
+*(May 19, 2026)*
+
+### Attendees
+
+- [Swapnil Dutta](https://github.com/rycerzes)
+- [Shaheem Azmal M MD](https://github.com/shaheemazmalmmd)
+- [Kaushlendra Pratap](https://github.com/Kaushl2208)
+- [Ayush Bhardwaj](https://github.com/hastagAB)
+
+### Discussion
+
+- Held an initial one-on-one project discussion focused on **Enhancing Nirjas & Atarashi**.
+- Discussed expected scope and implementation sequencing for the project.
+- Key mentor direction: **focus first on Nirjas classifier path**, then progressively integrate and optimize Atarashi.
+- Agreed to prioritize robust data and classifier foundations early to reduce downstream integration risk.
+
+## Project Planning Notes (from proposal)
+
+- Primary near-term focus:
+  1. Build/validate Nirjas data pipeline and classifier path.
+  2. Improve extraction reliability for license-relevant text.
+  3. Establish measurable baselines before Atarashi model-track selection.
+
+- Planned architecture direction:
+  - Parser-aware Nirjas extraction + classifier filtering.
+  - Signal-driven Atarashi retrieval/classification with confidence-aware outputs.
+
+## Previous Work / PRs Considered for Alignment
+
+To avoid duplicating effort and to align with FOSSology's prior design decisions, these references are being used during planning:
+
+- [fossology/fossology#1634](https://github.com/fossology/fossology/pull/1634) - earlier Atarashi integration direction.
+- [fossology/atarashi#109](https://github.com/fossology/atarashi/pull/109) - KeywordAgent and pre-filtering work.
+- [fossology/Nirjas#63](https://github.com/fossology/Nirjas/pull/63) - Nirjas bug fix relevant to extraction reliability.
+- [fossology/atarashi#99](https://github.com/fossology/atarashi/pull/99), [fossology/atarashi#100](https://github.com/fossology/atarashi/pull/100) - early Atarashi model-agent work.
+- [fossology/Minerva-Dataset-Generation#4](https://github.com/fossology/Minerva-Dataset-Generation/pull/4), [#5](https://github.com/fossology/Minerva-Dataset-Generation/pull/5) - model/data packaging patterns.
+- [fossology/atarashi#103](https://github.com/fossology/atarashi/pull/103) - semantic search integration work.
+
+## Plan for Next Week
+
+- Finalize the first Nirjas-focused implementation milestone.
+- Lock down dataset/evaluation checklist for the classifier baseline.
+- Share first coding-period progress update with concrete metrics and blockers (if any).

--- a/docs/2026/enhancing-atarashi/updates/_category_.json
+++ b/docs/2026/enhancing-atarashi/updates/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Weekly Updates",
+  "position": 2
+}


### PR DESCRIPTION
## Project
Enhancing Nirjas & Atarashi for Accurate, Scalable License Intelligence

### Changes
- Updated `docs/2026/enhancing-atarashi/index.md` with project intro, scope, deliverables, and expected outcomes.
- Added `docs/2026/enhancing-atarashi/updates/_category_.json`.
- Added community bonding report: `docs/2026/enhancing-atarashi/updates/2026-05-24.md`:
  - 08-05-2026: full FOSSology GSoC intro session
  - 19-05-2026: project-specific sync with Shaheem, Kaushal, Ayush
  - captured direction to prioritize Nirjas classifier first.
