### PR TITLE
docs: add weekly sync notes for 26 May, 2 June, and 9 June 2026

### DIFF
--- a/docs/2026/enhancing-atarashi/updates/2026-05-26.md
+++ b/docs/2026/enhancing-atarashi/updates/2026-05-26.md
@@ -1,0 +1,32 @@
+---
+title: Weekly Sync (26 May 2026)
+author: Swapnil Dutta
+tags: [gsoc26, nirjas, atarashi]
+---
+
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2026 Swapnil Dutta <swapnil@rycerz.es>
+-->
+
+# Weekly Sync - 26 May 2026
+
+## Attendees
+
+- [Swapnil Dutta](https://github.com/rycerzes)
+- [Shaheem Azmal M MD](https://github.com/shaheemazmalmmd)
+- [Kaushlendra Pratap](https://github.com/Kaushl2208)
+- [Ayush Bhardwaj](https://github.com/hastagAB)
+
+## Discussion
+
+- CI pipeline: Agreed to adopt `ruff` for linting and `pyright` for static typing checks as lightweight CI steps. We'll add a minimal workflow that runs fast on PRs and a more thorough workflow for merges.
+- Package managers: Preference for `poetry` to handle virtualenvs and reproducible installs. Action: confirm compatibility with other project toolchains; reference existing patterns from Safaa and Atarashi projects before finalizing.
+- Nirjas extraction: Two parallel work streams: (1) **Tooling upgrade PR** covering `ruff`, `pyright`, and `poetry` setup; (2) **Full refactor PR** implementing Tree-sitter based extraction with updated APIs. Decouple CI and tests from the main refactor to make incremental changes safer and allow independent review cycles.
+
+## Action Items
+
+- Complete and merge the **tooling upgrade PR** (CI, linting, package manager config).
+- Prepare the **full refactor PR** with decoupled test suite and incremental checkpoints.
+- Follow up with package manager decisions and cross-project alignments.

--- a/docs/2026/enhancing-atarashi/updates/2026-06-02.md
+++ b/docs/2026/enhancing-atarashi/updates/2026-06-02.md
@@ -1,0 +1,31 @@
+---
+title: Weekly Sync (2 June 2026)
+author: Swapnil Dutta
+tags: [gsoc26, nirjas, atarashi]
+---
+
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2026 Swapnil Dutta <swapnil@rycerz.es>
+-->
+
+# Weekly Sync - 2 June 2026
+
+## Attendees
+
+- [Swapnil Dutta](https://github.com/rycerzes)
+- [Shaheem Azmal M MD](https://github.com/shaheemazmalmmd)
+- [Kaushlendra Pratap](https://github.com/Kaushl2208)
+- [Ayush Bhardwaj](https://github.com/hastagAB)
+
+## Discussion
+
+- Pull request review: Reviewed the two parallel Nirjas PRs: tooling upgrade and full refactor. Maintainers requested clearer test coverage, incremental migration steps, and explicit API contracts for extraction results.
+- Feedback handling: Identified follow-up items for both PRs including test harness improvements, CI gating refinements, and documentation of the extraction output contract.
+
+## Action Items
+
+- Address feedback on both PRs (tooling and refactor) with focused follow-up commits.
+- Ensure test coverage includes parser compatibility checks and extraction normalization.
+- Coordinate re-review cycle with maintainers.

--- a/docs/2026/enhancing-atarashi/updates/2026-06-09.md
+++ b/docs/2026/enhancing-atarashi/updates/2026-06-09.md
@@ -1,0 +1,33 @@
+---
+title: Weekly Sync (9 June 2026)
+author: Swapnil Dutta
+tags: [gsoc26, nirjas, atarashi]
+---
+
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2026 Swapnil Dutta <swapnil@rycerz.es>
+-->
+
+# Weekly Sync - 9 June 2026
+
+## Attendees
+
+- [Swapnil Dutta](https://github.com/rycerzes)
+- [Shaheem Azmal M MD](https://github.com/shaheemazmalmmd)
+- [Kaushlendra Pratap](https://github.com/Kaushl2208)
+- [Ayush Bhardwaj](https://github.com/hastagAB)
+
+## Discussion
+
+- PR status: Reviewed the two Nirjas PRs (tooling and full refactor). Both on track pending minor test and documentation refinements. Agreed on prioritizing reproducible dataset artifacts and clear integration points.
+- Datasets & Minerva: Discussed dataset composition for Nirjas — include license corpora, non-license comments as hard negatives, and augmentations. Decided to produce explicit train/val/test splits with near-dup filtering.
+- Minerva integration: Agreed on a migration plan that adds the new pipeline as an optional submodule/component in Minerva, with a transition period where both pipelines run and results are compared.
+
+## Action Items
+
+- Finalize both Nirjas PRs (tooling and refactor) ready for merge.
+- Finalize Nirjas dataset schema, augmentation plan, and evaluation checklist.
+- Implement near-dedup and hard negative sampling in the data pipeline.
+- Draft the Minerva integration proposal with stepwise migration and compatibility tests.


### PR DESCRIPTION
## Project

Enhancing Nirjas & Atarashi for Accurate, Scalable License Intelligence

### Changes
- Added three weekly update pages:
  - 2026-05-26.md: CI tooling (`ruff`, `pyright`) and package manager (`poetry`) decisions
  - 2026-06-02.md: PR review feedback and maintainer alignment
  - 2026-06-09.md: Dataset finalization and Minerva integration planning
- Clarified two parallel PRs: tooling upgrade and full refactor (no PoC)

### Notes
- Weekly updates track Nirjas extraction (Tree-sitter) and Atarashi integration progress