### PR TITLE
docs(cyclonedx): add week 1 and 2 updates

### DIFF
--- a/docs/2026/cyclondx-support/updates/2026-06-11.md
+++ b/docs/2026/cyclondx-support/updates/2026-06-11.md
@@ -1,0 +1,50 @@
+---
+title: Week 1 & 2
+author: Krrish Biswas
+---
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2026 Krrish Biswas <krrishbiswas175@gmail.com>
+-->
+
+# Week 1 & 2 Updates
+
+## GSoC sync meeting Week 1
+
+**Date:** June 04, 2026  
+**Attendees:**
+- [Jan Altenberg](https://github.com/JanAltenberg) (Mentor)
+- [Krrish Biswas](https://github.com/krrish175-byte)
+
+### Summary:
+- Discussed how we are going to address the license and copyright gap in the CycloneDX 1.4 implementation.
+- Studied the current CycloneDX implementation in `src/cyclonedx/` and understood the export logic.
+- Identified feature gaps in the CycloneDX 1.4 implementation compared to the SPDX agent.
+- Found that `generateLicense()` supports `textContent` but the calling code in `cyclonedx.php` did not pass the license text.
+
+### Next Steps:
+- Add license texts and copyrights to the main component of the CycloneDX export.
+- Create an initial Pull Request addressing these gaps.
+
+## GSoC sync meeting Week 2
+
+**Date:** June 11, 2026  
+**Attendees:**
+- [Jan Altenberg](https://github.com/JanAltenberg) (Mentor)
+- [Krrish Biswas](https://github.com/krrish175-byte)
+
+### Summary:
+- Discussed the implementation and whether testing and other related tasks are needed.
+- Added license text and copyright notices to the main component of the CycloneDX export.
+- Ensured license text is aggregated unconditionally into the main component, while file components only reference the license IDs.
+- Fixed a deduplication bug caused by composite keys in the `$seenLicenseIds` array.
+- Tested the changes locally using a local FOSSology instance and validated the export structure.
+- Opened a Pull Request to fix the license text and copyright gaps (currently under review).
+- Prepared the implementation plan for the second PR, which will add Component Version, PURL, descriptions, and external references to match SPDX parity.
+
+### Next Steps:
+- Address any remaining review comments on the first PR.
+- Open the second PR to fix the remaining CycloneDX 1.4 gaps.
+- Validate the output against the CycloneDX 1.4 JSON schema.
+- Begin preparations for upgrading the spec version from 1.4 to 1.7.

--- a/docs/2026/cyclondx-support/updates/_category_.json
+++ b/docs/2026/cyclondx-support/updates/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Weekly Updates",
+  "position": 2
+}


### PR DESCRIPTION
## Project

CycloneDX SBOM support in FOSSology - Upgrading the export from spec version 1.4 to 1.7

### Changes

Week 1 and 2 updates
