### PR TITLE
docs(cyclonedx): add week 3 & 4 updates

### DIFF
--- a/docs/2026/cyclondx-support/updates/2026-06-25.md
+++ b/docs/2026/cyclondx-support/updates/2026-06-25.md
@@ -1,0 +1,50 @@
+---
+title: Week 3 & 4
+author: Krrish Biswas
+---
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2026 Krrish Biswas <krrishbiswas175@gmail.com>
+-->
+
+# Week 3 & 4 Updates
+
+## GSoC sync meeting Week 3
+
+**Date:** June 18, 2026  
+**Attendees:**
+- [Jan Altenberg](https://github.com/JanAltenberg) (Mentor)
+- [Krrish Biswas](https://github.com/krrish175-byte)
+
+### Summary:
+- Focused on Phase 1, Part 2: closing the remaining metadata gaps between the CycloneDX and SPDX agent outputs.
+- Implemented support for Component Version, Package URL (PURL), Description, External References (distribution and VCS URLs), Acknowledgements, and Comments.
+- Fixed a loose comparison bug in PHP that was misidentifying PURLs.
+- Developed a comprehensive isolated test suite (`test_report_output.php`) with 78 assertions to validate the CycloneDX outputs.
+- Submitted the second Pull Request (currently under review).
+- Discussed integration testing. Jan will test both PRs combined in the actual FOSSology environment.
+
+### Next Steps:
+- Create a combined branch containing both PRs for full integration testing.
+- Wait for client feedback on the first PR (which is being evaluated in real-world environments) before moving to Phase 2 (CycloneDX 1.7 upgrade).
+- Continue monitoring the second PR for review feedback.
+
+## GSoC sync meeting Week 4
+
+**Date:** June 25, 2026  
+**Attendees:**
+- [Jan Altenberg](https://github.com/JanAltenberg) (Mentor)
+- [Krrish Biswas](https://github.com/krrish175-byte)
+
+### Summary:
+- Received wonderful news that Part 1 of Phase 1 (license and copyright additions) was officially merged into the master branch!
+- The merged code is currently being evaluated by clients to gather feedback, which will inform when to officially start Phase 2.
+- Created a `test/combined-cdx` branch and merged both PRs to ensure there are no integration conflicts. The rebase against the latest `master` was completely clean.
+- Received and addressed code review feedback from Sushant on the second PR (added the missing `externalReferences` key to the report-level `$bomdata` array).
+- Pushed the updated fix to the PR and confirmed all CI checks passed successfully.
+
+### Next Steps:
+- Await client testing results on the merged Phase 1 code.
+- Wait for final approval and merge of the second PR closing the remaining CycloneDX 1.4 metadata gaps.
+- Prepare to scope out requirements and begin the upgrade to CycloneDX 1.7 (Phase 2) once client feedback confirms the current implementation is solid.


### PR DESCRIPTION
This PR adds the weekly GSoC updates for Week 3 and 4 of the CycloneDX project.