### PR TITLE
docs: add Week 5 & 6 update for CycloneDX Support project

### DIFF
--- a/docs/2026/cyclondx-support/updates/2026-07-16.md
+++ b/docs/2026/cyclondx-support/updates/2026-07-16.md
@@ -1,0 +1,47 @@
+---
+title: Week 5 & 6
+author: Krrish Biswas
+---
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+SPDX-FileCopyrightText: 2026 Krrish Biswas <krrishbiswas175@gmail.com>
+-->
+
+# Week 5 & 6 Updates
+
+## GSoC sync meeting Week 5
+
+**Date:** July 9, 2026  
+**Attendees:**
+- [Jan Altenberg](https://github.com/JanAltenberg) (Mentor)
+- [Krrish Biswas](https://github.com/krrish175-byte)
+
+### Summary:
+- Completed the GSoC Midterm Evaluations successfully.
+- Began working on Phase 2 of the project: upgrading the export to CycloneDX Spec Version 1.7.
+- Implemented a massive file size optimization by deduplicating license texts. Moved the large base64 encoded license blocks to the top-level package metadata and used `bom-ref` linking for components.
+- Raised PR #3705 for the CycloneDX 1.7 export and license deduplication feature.
+
+### Next Steps:
+- Monitor PR #3705 for reviews.
+- Discuss further enhancements for CycloneDX UI and settings.
+
+## GSoC sync meeting Week 6
+
+**Date:** July 16, 2026  
+**Attendees:**
+- [Jan Altenberg](https://github.com/JanAltenberg) (Mentor)
+- Shaheem
+- [Krrish Biswas](https://github.com/krrish175-byte)
+
+### Summary:
+- Received feedback during the meeting to implement configurable user default settings for CycloneDX exports, mirroring the behavior of the SPDX/Osselot settings.
+- Proposed an architectural solution on the public Slack channel outlining changes to the database schema, UI, and backend. The proposal was approved by the team.
+- Developed the user settings feature: added `cyclonedx_settings` to `core-schema.dat`, updated `UploadDao.php` to fetch settings, and modified `user-edit.php` and its twig template to add UI checkboxes.
+- Raised a new, separate PR (#3714) for the user default settings to keep reviews focused and distinct from the 1.7 export PR.
+
+### Next Steps:
+- Gather feedback and reviews on both PR #3705 and PR #3714.
+- Address any change requests from the maintainers.
+- Plan the next phase of the CycloneDX improvements once these foundational features are merged.


### PR DESCRIPTION
Adding GSoC updates for weeks 5 and 6 covering the CycloneDX 1.7 export upgrade and the new user configurable default settings.